### PR TITLE
FEATURE: Provider 2FA

### DIFF
--- a/service/middlewares/auth.js
+++ b/service/middlewares/auth.js
@@ -283,7 +283,7 @@ passport.use(
   "2fa-request",
   new localStrategy(
     {
-      usernameField: "password",
+      usernameField: "email",
       passwordField: "password",
       passReqToCallback: true,
     },
@@ -295,7 +295,7 @@ passport.use(
         const { email, password } = await provider2FARequestSchema
           .noUnknown(true)
           .strict()
-          .validate({ ...req.body, password: passwordIn })
+          .validate({ ...req.body, email: emailIn, password: passwordIn })
           .catch((err) => {
             throw err;
           });
@@ -332,7 +332,7 @@ passport.use(
           const lastOTPTime = new Date(userLastOTP.created_at).getTime();
           const now = new Date().getTime();
 
-          if ((lastOTPTime - now) / 1000 < 60) {
+          if ((now - lastOTPTime) / 1000 < 60) {
             // Users can request one OTP every 60 seconds
             throw tooManyOTPRequests();
           } else {

--- a/service/middlewares/auth.js
+++ b/service/middlewares/auth.js
@@ -87,8 +87,8 @@ passport.use(
               throw err;
             });
         } else if (userType === "provider") {
-          // randomlyGeneratedPassword = generatePassword(10);
-          hashedPass = await bcrypt.hash(password, salt);
+          randomlyGeneratedPassword = generatePassword(10);
+          hashedPass = await bcrypt.hash(randomlyGeneratedPassword, salt);
           currentUser = await getProviderUserByEmail(
             country,
             providerData.email

--- a/service/queries/authOTP.js
+++ b/service/queries/authOTP.js
@@ -1,0 +1,46 @@
+import { getDBPool } from "#utils/dbConfig";
+
+export const storeAuthOTP = async (poolCountry, user_id, otp) =>
+  await getDBPool("piiDb", poolCountry).query(
+    `
+        INSERT INTO auth_otp (otp, user_id)
+        VALUES ($1, $2)
+        RETURNING *;
+    `,
+    [otp, user_id]
+  );
+
+export const getAuthOTP = async (poolCountry, otp, user_id) =>
+  await getDBPool("piiDb", poolCountry).query(
+    `
+        SELECT otp, user_id, user, created_at
+        FROM auth_otp
+        WHERE otp = $1 
+          AND user_id = $2
+          AND used = false;
+    `,
+    [otp, user_id]
+  );
+
+export const getUserLastAuthOTP = async (poolCountry, user_id) =>
+  await getDBPool("piiDb", poolCountry).query(
+    `
+        SELECT id, otp, user_id, user, created_at
+        FROM auth_otp
+        WHERE user_id = $1
+          AND used = false
+        ORDER BY created_at DESC
+        LIMIT 1;
+    `,
+    [user_id]
+  );
+
+export const changeOTPToUsed = async (poolCountry, otp_id) =>
+  await getDBPool("piiDb", poolCountry).query(
+    `
+        UPDATE auth_otp
+        SET used = true
+        WHERE id = $1;
+    `,
+    [otp_id]
+  );

--- a/service/queries/authOTP.js
+++ b/service/queries/authOTP.js
@@ -13,7 +13,7 @@ export const storeAuthOTP = async (poolCountry, user_id, otp) =>
 export const getAuthOTP = async (poolCountry, otp, user_id) =>
   await getDBPool("piiDb", poolCountry).query(
     `
-        SELECT otp, user_id, user, created_at
+        SELECT *
         FROM auth_otp
         WHERE otp = $1 
           AND user_id = $2
@@ -25,10 +25,9 @@ export const getAuthOTP = async (poolCountry, otp, user_id) =>
 export const getUserLastAuthOTP = async (poolCountry, user_id) =>
   await getDBPool("piiDb", poolCountry).query(
     `
-        SELECT id, otp, user_id, user, created_at
+        SELECT *
         FROM auth_otp
         WHERE user_id = $1
-          AND used = false
         ORDER BY created_at DESC
         LIMIT 1;
     `,

--- a/service/routes/v1/authRouter.js
+++ b/service/routes/v1/authRouter.js
@@ -120,4 +120,17 @@ router.post("/refresh-token", async (req, res, next) => {
     .catch(next);
 });
 
+router.post(
+  "/2fa",
+  passport.authenticate("2fa-request", { session: false }),
+  async (req, res) => {
+    /**
+     * #route   POST /user/v1/auth/2fa
+     * #desc    Request 2fa OTP
+     */
+
+    return res.status(200).send(req.user);
+  }
+);
+
 export { router };

--- a/service/schemas/authSchemas.js
+++ b/service/schemas/authSchemas.js
@@ -25,6 +25,15 @@ export const userLoginSchema = (language) =>
           .string()
           .required(t("email_or_access_token_required_error", language)),
       }),
+      otp: yup.string().when("userType", {
+        is: "provider",
+        then: yup.string().length(4).required(),
+      }),
     },
-    ["userAccessToken", "email"]
+    ["userAccessToken", "email", "otp"]
   );
+
+export const provider2FARequestSchema = yup.object().shape({
+  password: yup.string().required(),
+  email: yup.string().email().required(),
+});

--- a/service/translations/en.js
+++ b/service/translations/en.js
@@ -17,4 +17,5 @@ export default {
   invalid_refresh_token_error: "Refresh token invalid or already used",
   cannot_generate_user_access_token_error: `Couldn't generate a new random user access token. Please try again`,
   invalid_reset_password_token_error: "Invalid or expired reset password token",
+  invalid_provider_otp_error: "Invalid OTP",
 };

--- a/service/translations/en.js
+++ b/service/translations/en.js
@@ -18,4 +18,6 @@ export default {
   cannot_generate_user_access_token_error: `Couldn't generate a new random user access token. Please try again`,
   invalid_reset_password_token_error: "Invalid or expired reset password token",
   invalid_provider_otp_error: "Invalid OTP",
+  too_many_otp_requests_error:
+    "Too many OTP requests made, please try again soon.",
 };

--- a/service/utils/errors.js
+++ b/service/utils/errors.js
@@ -40,6 +40,14 @@ export const incorrectPassword = (language) => {
   return error;
 };
 
+export const invalidOTP = (language) => {
+  const error = new Error();
+  error.message = t("invalid_provider_otp_error", language);
+  error.name = "INVALID OTP";
+  error.status = 401;
+  return error;
+};
+
 export const notAuthenticated = (language) => {
   const error = new Error();
   error.message = t("not_authenticated_error", language);

--- a/service/utils/errors.js
+++ b/service/utils/errors.js
@@ -95,3 +95,11 @@ export const countryNotFound = (language) => {
   error.status = 404;
   return error;
 };
+
+export const tooManyOTPRequests = (language) => {
+  const error = new Error();
+  error.message = t("too_many_otp_requests_error", language);
+  error.name = "TOO MANY OTP REQUESTS";
+  error.status = 429;
+  return error;
+};

--- a/service/utils/helperFunctions.js
+++ b/service/utils/helperFunctions.js
@@ -76,3 +76,7 @@ export const generatePassword = (length) => {
   if (passwordPattern.test(password)) return password;
   else return generatePassword(length);
 };
+
+export const generate4DigitCode = () => {
+  return Math.floor(Math.random() * 9000 + 1000);
+};


### PR DESCRIPTION
- Added new endpoint to request 2FA OTP that is required when provider users login
- Provider users now need to provide a 4-digit OTP during login
- 2FA OTP expires after 30 minutes from being sent
- Users can request 2FA OTP codes every 60 seconds as a security measure against DDOS attacks